### PR TITLE
[env-properties-in-annotation] - Add support to environment variables in @S3PropertiesLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,18 @@ There 2 ways to configure your application to load properties from s3:
 
 **Anotation**
 
-Add this annotation to any spring managed bean
+- Adding this annotation to any spring managed bean
 ```java
 @S3PropertiesLocation("my-bucket/my-folder/my-properties.properties")
 ```
-or using a specific profile to only load properties if the app is running with that profile
+- Using a specific profile to only load properties if the app is running with that profile
 ```java
 @S3PropertiesLocation(path = "my-bucket/my-folder/my-properties.properties", profiles = "production")
 ```
-
+- Load from a System env variable
+```java
+@S3PropertiesLocation(path = "${AWS_S3_LOCATION}", profiles = "production")
+```
 **Configuration**
 ```java
 @Bean

--- a/build.gradle
+++ b/build.gradle
@@ -63,10 +63,12 @@ repositories {
 dependencies {
     compile "org.springframework:spring-context:4.3.4.RELEASE"
     compile "org.springframework.cloud:spring-cloud-aws-core:1.1.3.RELEASE"
-    
+
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:1.10.19"
     testCompile "org.assertj:assertj-core:1.0.0"
+    testCompile "org.powermock:powermock-api-mockito:1.6.6"
+    testCompile "org.powermock:powermock-module-junit4:1.6.6"
 }
 
 task sourcesJar(type: Jar) {

--- a/src/main/java/com/spring/loader/S3PropertiesLocation.java
+++ b/src/main/java/com/spring/loader/S3PropertiesLocation.java
@@ -25,7 +25,8 @@ public @interface S3PropertiesLocation {
 	/**
 	 * The location of the properties in aws s3.
 	 * 
-	 * @return the path of aws s3 properties, e.g. my-bucket/my-folder/app.properties  
+	 * @return the path of aws s3 properties 			e.g. "my-bucket/my-folder/app.properties"
+	 * 		   or a enviroment system to the s3 path    e.g. "${MY_BUCKET_IN_AWS_S3}"
 	 */
 	@AliasFor("path")
 	String[] value() default {};

--- a/src/main/java/com/spring/loader/S3PropertiesLocationRegistrar.java
+++ b/src/main/java/com/spring/loader/S3PropertiesLocationRegistrar.java
@@ -12,6 +12,8 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotationMetadata;
 
+import com.spring.loader.resolver.SystemPropertyResolver;
+
 /**
  * Creates the {@link S3PropertyPlaceholderConfigurer} bean.
  * For use with the {@link S3PropertiesLocation} annotation. 
@@ -24,6 +26,16 @@ import org.springframework.core.type.AnnotationMetadata;
 class S3PropertiesLocationRegistrar implements EnvironmentAware, ImportBeanDefinitionRegistrar {
 	
 	private Environment environment;
+	private SystemPropertyResolver resolver;
+
+	public S3PropertiesLocationRegistrar() {
+		resolver = new SystemPropertyResolver();
+	}
+
+	public S3PropertiesLocationRegistrar(Environment environment, SystemPropertyResolver resolver) {
+		this.environment = environment;
+		this.resolver = resolver;
+	}
 
 	@Override
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
@@ -35,11 +47,16 @@ class S3PropertiesLocationRegistrar implements EnvironmentAware, ImportBeanDefin
 		}
 		
 		String[] locations = attributes.getStringArray("value");
-		
+		String[] formattedLocations = new String[locations.length]; 
+
+		for (int i = 0; i < locations.length; i++) {
+			formattedLocations[i] = resolver.getFormattedValue(locations[i]);
+		}
+
 		BeanDefinition bd = new RootBeanDefinition(S3PropertyPlaceholderConfigurer.class);
 		
 		bd.getPropertyValues().addPropertyValue("s3ResourceLoader", new RuntimeBeanReference("s3ResourceLoader")); 
-		bd.getPropertyValues().add("s3Locations", locations);
+		bd.getPropertyValues().add("s3Locations", formattedLocations);
 		
 		String beanName = S3PropertyPlaceholderConfigurer.class.getSimpleName();
 		registry.registerBeanDefinition(toLowerCase(beanName.charAt(0)) + beanName.substring(1), bd);

--- a/src/main/java/com/spring/loader/exception/EnviromentPropertyNotFoundException.java
+++ b/src/main/java/com/spring/loader/exception/EnviromentPropertyNotFoundException.java
@@ -1,0 +1,10 @@
+package com.spring.loader.exception;
+
+public class EnviromentPropertyNotFoundException extends S3ResourceException {
+	private static final long serialVersionUID = -3434756303367606716L;
+
+	public EnviromentPropertyNotFoundException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/com/spring/loader/resolver/SystemPropertyResolver.java
+++ b/src/main/java/com/spring/loader/resolver/SystemPropertyResolver.java
@@ -1,0 +1,42 @@
+package com.spring.loader.resolver;
+
+import static java.lang.String.format;
+import static org.springframework.util.StringUtils.isEmpty;
+
+import com.spring.loader.exception.EnviromentPropertyNotFoundException;
+import com.spring.loader.exception.InvalidS3LocationException;
+
+/**
+ * Resolver for properties that will be retrieved from system environment. 
+ * 
+ * @author Eric Dallo
+ * @since 1.0.5
+ */
+public class SystemPropertyResolver {
+
+	private static final String SYSTEM_NOTATION_PREFIX = "${";
+	private static final String SYSTEM_NOTATION_SUFIX = "}";
+
+	public String getFormattedValue(String value) {
+		if (isEmpty(value)) {
+			throw new InvalidS3LocationException("The location cannot be empty or null");
+		}
+		if (value.startsWith(SYSTEM_NOTATION_PREFIX)) {
+			
+			if (value.endsWith(SYSTEM_NOTATION_SUFIX)) {
+				String rawProperty = value.substring(SYSTEM_NOTATION_PREFIX.length(), value.length() - SYSTEM_NOTATION_SUFIX.length());
+				String valueFromEnv = System.getenv(rawProperty);
+				
+				if (isEmpty(valueFromEnv)) {
+					throw new EnviromentPropertyNotFoundException(format("Enviroment variable %s not found in system", rawProperty));
+				}
+				
+				return valueFromEnv;
+			}
+			throw new InvalidS3LocationException("Syntax error for system property: " + value);
+		}
+		
+		return value;
+	}
+
+}

--- a/src/test/java/com/spring/loader/resolver/SystemPropertyResolverTest.java
+++ b/src/test/java/com/spring/loader/resolver/SystemPropertyResolverTest.java
@@ -1,0 +1,73 @@
+package com.spring.loader.resolver;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.spring.loader.exception.EnviromentPropertyNotFoundException;
+import com.spring.loader.exception.InvalidS3LocationException;
+
+@PrepareForTest(SystemPropertyResolver.class)
+@RunWith(PowerMockRunner.class)
+public class SystemPropertyResolverTest {
+	
+	private SystemPropertyResolver subject;
+
+	@Before
+	public void setup() {
+		subject = new SystemPropertyResolver();
+		PowerMockito.mockStatic(System.class);
+	}
+
+	@Test
+	public void shouldGetFormattedValueWhenValueIsValid() {
+		String expected = "someValue";
+		
+		PowerMockito.when(System.getenv(Mockito.eq("AWS_S3"))).thenReturn(expected);
+		
+		String env = "${AWS_S3}";
+		
+		String formattedValue = subject.getFormattedValue(env);
+		
+		assertEquals(expected, formattedValue);
+	}
+	
+	@Test
+	public void shouldGetFormattedValueWhenValueIsValidAndNotASystemEnv() {
+		String expected = "someValue";
+		
+		String formattedValue = subject.getFormattedValue(expected);
+		
+		assertEquals(expected, formattedValue);
+	}
+	
+	@Test(expected = InvalidS3LocationException.class)
+	public void shouldNotGetFormattedValueWhenValueIsEmpty() {
+		String expected = "";
+		
+		subject.getFormattedValue(expected);
+	}
+	
+	@Test(expected = InvalidS3LocationException.class)
+	public void shouldNotGetFormattedValueWhenValueHasAInvalidSyntax() {
+		String expected = "${AWS_S3";
+		
+		subject.getFormattedValue(expected);
+	}
+	
+	@Test(expected = EnviromentPropertyNotFoundException.class)
+	public void shouldNotGetFormattedValueWhenSystemDoesNotHasTheEnvironmentVariable() {
+		PowerMockito.when(System.getenv(Mockito.eq("AWS_S3"))).thenReturn(null);
+		
+		String env = "${AWS_S3}";
+		
+		subject.getFormattedValue(env);
+	}
+
+}


### PR DESCRIPTION
Example:

```java
@S3PropertiesLocation("${AWS_S3}")
```