### PR TITLE
Allowing a more fine granular system env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Maven:
 ```
 - Using a specific profile to only load properties if the app is running with that profile
 ```java
-@S3PropertiesLocation(path = "my-bucket/my-folder/my-properties.properties", profiles = "production")
+@S3PropertiesLocation(value = "my-bucket/my-folder/my-properties.properties", profiles = "production")
 ```
 - Load from a System env variable
 ```java
-@S3PropertiesLocation(path = "${AWS_S3_LOCATION}", profiles = "developer")
+@S3PropertiesLocation(value = "${AWS_S3_LOCATION}", profiles = "developer")
 ```
 
 ## Requisites

--- a/src/main/java/com/spring/loader/SystemPropertyResolver.java
+++ b/src/main/java/com/spring/loader/SystemPropertyResolver.java
@@ -6,6 +6,9 @@ import static org.springframework.util.StringUtils.isEmpty;
 import com.spring.loader.exception.EnviromentPropertyNotFoundException;
 import com.spring.loader.exception.InvalidS3LocationException;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Resolver for properties that will be retrieved from system environment. 
  * 
@@ -15,28 +18,39 @@ import com.spring.loader.exception.InvalidS3LocationException;
 public class SystemPropertyResolver {
 
 	private static final String SYSTEM_NOTATION_PREFIX = "${";
-	private static final String SYSTEM_NOTATION_SUFIX = "}";
 
 	public String getFormattedValue(String value) {
 		if (isEmpty(value)) {
 			throw new InvalidS3LocationException("The location cannot be empty or null");
 		}
-		if (value.startsWith(SYSTEM_NOTATION_PREFIX)) {
-			
-			if (value.endsWith(SYSTEM_NOTATION_SUFIX)) {
-				String rawProperty = value.substring(SYSTEM_NOTATION_PREFIX.length(), value.length() - SYSTEM_NOTATION_SUFIX.length());
-				String valueFromEnv = System.getenv(rawProperty);
-				
-				if (isEmpty(valueFromEnv)) {
-					throw new EnviromentPropertyNotFoundException(format("Enviroment variable %s not found in system", rawProperty));
-				}
-				
-				return valueFromEnv;
+
+		if (value.contains(SYSTEM_NOTATION_PREFIX)) {
+			String bucket = value;
+			String pattern = "\\$\\{([A-Za-z0-9_\\-\\.]+)\\}";
+			Matcher matcher = Pattern.compile(pattern).matcher(bucket);
+			while (matcher.find()) {
+				String envValue = getFromEnv(matcher.group(1));
+				Pattern subExpression = Pattern.compile(Pattern.quote(matcher.group(0)));
+				bucket = subExpression.matcher(bucket).replaceAll(envValue);
 			}
-			throw new InvalidS3LocationException("Syntax error for system property: " + value);
+
+			if (bucket.contains(SYSTEM_NOTATION_PREFIX)) {
+				throw new InvalidS3LocationException("Syntax error for system property: " + value);
+			}
+
+			return bucket;
 		}
 		
 		return value;
 	}
 
+	private String getFromEnv(String key) {
+		String valueFromEnv = System.getenv(key);
+
+		if (isEmpty(valueFromEnv)) {
+			throw new EnviromentPropertyNotFoundException(format("Environment variable %s not found in system", key));
+		}
+
+		return valueFromEnv;
+	}
 }

--- a/src/test/java/com/spring/loader/resolver/SystemPropertyResolverTest.java
+++ b/src/test/java/com/spring/loader/resolver/SystemPropertyResolverTest.java
@@ -28,17 +28,47 @@ public class SystemPropertyResolverTest {
 
 	@Test
 	public void shouldGetFormattedValueWhenValueIsValid() {
-		String expected = "someValue";
+		String expected = "someBucket/someProperty.file";
 		
-		PowerMockito.when(System.getenv(Mockito.eq("AWS_S3"))).thenReturn(expected);
+		PowerMockito.when(System.getenv(Mockito.eq("AWS_S3-BUCKET.file"))).thenReturn(expected);
 		
-		String env = "${AWS_S3}";
+		String env = "${AWS_S3-BUCKET.file}";
 		
 		String formattedValue = subject.getFormattedValue(env);
 		
 		assertEquals(expected, formattedValue);
 	}
-	
+
+	@Test
+	public void shouldGetCombinedFormattedValueWhenValueIsValid() {
+		String region = "someRegion";
+		String environment = "someEnvironment";
+
+		PowerMockito.when(System.getenv(Mockito.eq("S3_BUCKET_REGION"))).thenReturn(region);
+		PowerMockito.when(System.getenv(Mockito.eq("S3_BUCKET_ENVIRONMENT"))).thenReturn(environment);
+
+		String configValue = "${S3_BUCKET_REGION}/${S3_BUCKET_ENVIRONMENT}/myApplication/application.properties";
+		String expected = String.format("%s/%s/myApplication/application.properties", region, environment);
+
+		String formattedValue = subject.getFormattedValue(configValue);
+
+		assertEquals(expected, formattedValue);
+	}
+
+	@Test
+	public void shouldReplaceMultiple() {
+		String environment = "dev";
+
+		PowerMockito.when(System.getenv(Mockito.eq("EC2_ENVIRONMENT"))).thenReturn(environment);
+
+		String configValue = "region-${EC2_ENVIRONMENT}/deploy-${EC2_ENVIRONMENT}/application.properties";
+		String expected = String.format("region-%s/deploy-%s/application.properties", environment, environment);
+
+		String formattedValue = subject.getFormattedValue(configValue);
+
+		assertEquals(expected, formattedValue);
+	}
+
 	@Test
 	public void shouldGetFormattedValueWhenValueIsValidAndNotASystemEnv() {
 		String expected = "someValue";


### PR DESCRIPTION
In our project we are sharing one ec2 between several applications on the dev/test environment, so we get a much nicer environment variable setup if it's possible to concatenate the S3PropertiesLocation.
Hope you'll find it a good enhancement.